### PR TITLE
Build win11 cu11.8

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,3 +1,13 @@
-cd %SRC_DIR%/Python
+@echo on
 
-%PYTHON% setup.py install
+call "C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\VC\Auxiliary\Build\vcvarsall.bat" x64
+
+REM Check if the Python executable exists
+if not exist "%PYTHON%" (
+    echo Error: Python executable not found at %PYTHON%
+    exit /b 1
+)
+
+cd /D %SRC_DIR%/Python
+
+%PYTHON% -m pip install .

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,4 +1,5 @@
-#creates pairs of versions using zip_keys, lists must be the same length
+cuda_compiler_version:
+  - '11.8'
 python:
   - 3.10 
   - 3.10 

--- a/recipe/cuda_home.patch
+++ b/recipe/cuda_home.patch
@@ -1,0 +1,26 @@
+--- Python/tigre/__init__.py	2024-09-09 14:28:47.269367100 +0100
++++ Python/tigre/__init__.py.modified	2024-09-09 14:31:08.320835100 +0100
+@@ -1,23 +1,5 @@
+ from __future__ import division, absolute_import, print_function
+ 
+-# fix for DLL import issue on python 3.8 or higher on windows
+-# related to: 
+-# https://github.com/CERN/TIGRE/issues/247
+-# https://github.com/CERN/TIGRE/issues/349
+-import os
+-
+-if hasattr(os, "add_dll_directory"):
+-    # Add all the DLL directories manually
+-    # see:
+-    # https://docs.python.org/3.8/whatsnew/3.8.html#bpo-36085-whatsnew
+-    # https://stackoverflow.com/a/60803169/19344391
+-    dll_directory = os.path.dirname(__file__)
+-    os.add_dll_directory(dll_directory)
+-
+-    # The user must install the CUDA Toolkit
+-    cuda_bin = os.path.join(os.environ["CUDA_PATH"], "bin")
+-    os.add_dll_directory(cuda_bin)
+-
+ from .utilities.geometry import geometry
+ from .utilities.geometry_default import ConeGeometryDefault as geometry_default
+ from .utilities.Ax import Ax

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -3,12 +3,12 @@ package:
   version: {{ environ.get('GIT_DESCRIBE_TAG','v')[1:] }}
 
 source:
-#  git_rev: 3067d6b9d08875c2bbce4e6f06a5513119353bfe
   git_url: https://github.com/CERN/TIGRE.git
   git_rev: v2.6
   git_depth: 1
   patches:
     - setup.patch
+    - cuda_home.patch
 
 build:
   preserve_egg_dir: False
@@ -23,8 +23,6 @@ build:
     - $RPATH/libicuuc.so.60  #[linux]
     - $RPATH/libicui18n.so.60 #[linux]
     - $RPATH/libcudart.so.* #[linux]
-    - $RPATH/cudart64_*.dll #[win]
-    
 
 requirements:
   build:
@@ -45,8 +43,8 @@ requirements:
     - tqdm
     - libstdcxx-ng # [unix]
     - libgcc-ng # [unix]
-    - vc 14 # [win]
-    - cudatoolkit=11.2
+    - cudatoolkit {{ cuda_compiler_version }} 
+    - vc 14.2 # [win]
 
 about:
   home: https://github.com/CERN/TIGRE

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -46,7 +46,7 @@ requirements:
     - libstdcxx-ng # [unix]
     - libgcc-ng # [unix]
     - vc 14 # [win]
-    - cudatoolkit=11.8
+    - cudatoolkit=11.2
 
 about:
   home: https://github.com/CERN/TIGRE


### PR DESCRIPTION
Update build script and meta.yaml  for windows with VS 2019 and NVCC 11.8
Adds patch to address #7
Uses pip to instal rather than calling `setup.py` directly

closes #9 
closes #7 