### PR TITLE
fix build/host/run deps

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,8 @@ on:
 jobs:
   conda:
     defaults: {run: {shell: bash}}
-    runs-on: ${{ matrix.os }}-latest
+    # use oldest ubuntu image for max glibc compat https://stackoverflow.com/q/70019660
+    runs-on: ${{ matrix.os }}-${{ matrix.os == 'ubuntu' && '22.04' || 'latest' }}
     strategy:
       matrix:
         os: [ubuntu, windows]

--- a/pixi.toml
+++ b/pixi.toml
@@ -22,6 +22,21 @@ compilers = ["cxx"]
 # This will be default at some point, at which stage this can be removed
 ignore-pypi-mapping = false
 
+[package.build-dependencies]
+cuda-version = ">=12"
+cuda-toolkit = "*"
+
 [package.host-dependencies]
 python = "*"
-cuda-toolkit = "*"
+cuda-version = ">=12"
+
+[package.target.linux-64.host-dependencies]
+cuda-cudart-dev_linux-64 = "*"
+
+[package.target.win-64.host-dependencies]
+cuda-cudart-dev_win-64 = "*"
+
+[package.run-dependencies]
+python = "*"
+cuda-version = ">=12"
+__cuda = "*"


### PR DESCRIPTION
Attempt to fix things like https://github.com/TomographicImaging/CIL/pull/2317

- move `cuda-toolkit` from `host` -> `build` deps
- add `cudart` to `host` deps
- add `__cuda` to `run` deps
- use older `ubuntu-22.04` for maximum glibc compatibility
- ~move from `pixi` -> `ratter-build` to specify `ignore_run_exports.from_package: [cuda-toolkit]`~

/CC @JeppeKlitgaard