### PR TITLE
run deps: add cudart, fix python version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
         pixi-version: v0.68.1
         run-install: false
     - name: Build
-      run: pixi publish --target-dir dist/${{ matrix.os == 'ubuntu' && 'linux-64' || 'win-64' }} --build-number 1
+      run: pixi publish --target-dir dist/${{ matrix.os == 'ubuntu' && 'linux-64' || 'win-64' }} --build-number 2
     - name: Publish artifact
       uses: actions/upload-artifact@v7
       with:

--- a/pixi.toml
+++ b/pixi.toml
@@ -37,6 +37,5 @@ cuda-cudart-dev_linux-64 = "*"
 cuda-cudart-dev_win-64 = "*"
 
 [package.run-dependencies]
-python = "*"
 cuda-version = ">=12"
-__cuda = "*"
+cuda-cudart = "*"


### PR DESCRIPTION
- replace `__cuda` -> `cuda-cudart`
- drop `python="*"` in favour of auto-inferring from build variant

Fixes #21