### PR TITLE
bump pixi

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,21 +14,20 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu, windows]
-        # TODO: use CI matrix after https://github.com/prefix-dev/pixi/issues/4877 is fixed
-        # python: ['3.10', 3.11, 3.12, 3.13, 3.14]  # Follow NEP29
+        python: ['3.10', 3.11, 3.12, 3.13, 3.14]  # Follow NEP29
     steps:
     - uses: actions/checkout@v6
       with: {fetch-depth: 0}
     - uses: prefix-dev/setup-pixi@v0.9.5
       with:
-        pixi-version: v0.68.1
+        pixi-version: v0.69.0
         run-install: false
     - name: Build
-      run: pixi publish --target-dir dist/${{ matrix.os == 'ubuntu' && 'linux-64' || 'win-64' }} --build-number 2
+      run: pixi publish --target-dir dist/${{ matrix.os == 'ubuntu' && 'linux-64' || 'win-64' }} --variant python=${{ matrix.python }}.*
     - name: Publish artifact
       uses: actions/upload-artifact@v7
       with:
-        name: conda-package-${{ matrix.os }}
+        name: conda-package-${{ matrix.os }}-${{ matrix.python }}
         path: dist
     - if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags')
       name: conda upload -c ccpi

--- a/pixi.toml
+++ b/pixi.toml
@@ -24,19 +24,16 @@ compilers = ["cxx"]
 ignore-pypi-mapping = false
 
 [package.build-dependencies]
-cuda-version = ">=12"
-cuda-toolkit = "*"
+cuda-version = "12.*"
+cuda-nvcc = "*"
 
 [package.host-dependencies]
 python = "*"
-cuda-version = ">=12"
+cuda-version = "12.*"
+libcurand-dev = "*"
 
 [package.target.linux-64.host-dependencies]
 cuda-cudart-dev_linux-64 = "*"
 
 [package.target.win-64.host-dependencies]
 cuda-cudart-dev_win-64 = "*"
-
-[package.run-dependencies]
-cuda-version = ">=12"
-cuda-cudart = "*"

--- a/pixi.toml
+++ b/pixi.toml
@@ -11,6 +11,7 @@ python = ["3.10.*", "3.11.*", "3.12.*", "3.13.*", "3.14.*"]
 
 [package.build]
 backend = { name = "pixi-build-python", version = "*" }
+build-number = 3
 
 [package.build.source]
 git = "https://github.com/CERN/TIGRE.git"


### PR DESCRIPTION
- bump pixi
  + CI build matrix via `--variant`
  + `build-number` in `pixi.toml`
  + fixes missing python_abi version run export
- reduce build-dependencies
  + `cuda-toolkit` -> `cuda-nvcc`, `libcurand`
  + pin `cuda-version=12.*`
  + auto-infer all run-dependencies (via run exports)

Fixes #23
