### PR TITLE
cu12/13 split

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,6 +15,7 @@ jobs:
       matrix:
         os: [ubuntu, windows]
         python: ['3.10', 3.11, 3.12, 3.13, 3.14]  # Follow NEP29
+        cuda: [12, 13]
     steps:
     - uses: actions/checkout@v6
       with: {fetch-depth: 0}
@@ -23,7 +24,7 @@ jobs:
         pixi-version: v0.69.0
         run-install: false
     - name: Build
-      run: pixi publish --target-dir dist/${{ matrix.os == 'ubuntu' && 'linux-64' || 'win-64' }} --variant python=${{ matrix.python }}.*
+      run: pixi publish --target-dir dist/${{ matrix.os == 'ubuntu' && 'linux-64' || 'win-64' }} --variant python=${{ matrix.python }}.* --variant cuda-version=${{ matrix.cuda }} --build-string-prefix cu${{ matrix.cuda }}
     - name: Publish artifact
       uses: actions/upload-artifact@v7
       with:

--- a/pixi.toml
+++ b/pixi.toml
@@ -3,15 +3,14 @@ channels = ["nvidia", "conda-forge"]
 platforms = ["linux-64", "win-64"]
 preview = ["pixi-build"]
 
-[system-requirements]
-cuda = "12"
-
 [workspace.build-variants]
 python = ["3.10.*", "3.11.*", "3.12.*", "3.13.*", "3.14.*"]
+cuda-version = ["12.*"]
 
 [package.build]
 backend = { name = "pixi-build-python", version = "*" }
 build-number = 3
+build-string-prefix = "cu12"
 
 [package.build.source]
 git = "https://github.com/CERN/TIGRE.git"
@@ -24,12 +23,12 @@ compilers = ["cxx"]
 ignore-pypi-mapping = false
 
 [package.build-dependencies]
-cuda-version = "12.*"
+cuda-version = "*"
 cuda-nvcc = "*"
 
 [package.host-dependencies]
 python = "*"
-cuda-version = "12.*"
+cuda-version = "*"
 libcurand-dev = "*"
 
 [package.target.linux-64.host-dependencies]


### PR DESCRIPTION
Contrary to https://pixi.prefix.dev/latest/workspace/system_requirements/#using-cuda-in-pixi, this does not actually work (on `pixi==0.69`) as it does not specify min requirement:

```toml
[system-requirements]
cuda = "12"
```
